### PR TITLE
Add support for notEqual predicate for filter on Enum

### DIFF
--- a/src/main/java/org/omnifaces/persistence/service/GenericEntityService.java
+++ b/src/main/java/org/omnifaces/persistence/service/GenericEntityService.java
@@ -192,8 +192,15 @@ public class GenericEntityService {
 
 					if (type.isEnum()) {
 						try {
+							if (searchValue.startsWith("!")) {
+								searchValue = searchValue.substring(1);
+								exactPredicates.add(criteriaBuilder.notEqual(root.get(key), criteriaBuilder.parameter(type, searchKey)));
+							} else {
+								exactPredicates.add(criteriaBuilder.equal(root.get(key), criteriaBuilder.parameter(type, searchKey)));
+
+							}
+
 							Enum enumValue = Enum.valueOf((Class<Enum>) type, searchValue);
-							exactPredicates.add(criteriaBuilder.equal(root.get(key), criteriaBuilder.parameter(type, searchKey)));
 							searchParameters.put(searchKey, enumValue);
 						}
 						catch (IllegalArgumentException ignore) {


### PR DESCRIPTION
Useful for situations where you want any value of an enum except X. Use by prefixing a `!` to the filter value.