### PR TITLE
Fallback to like searchPredicate when Long doesn't match any of the listed conditions

### DIFF
--- a/src/main/java/org/omnifaces/persistence/service/GenericEntityService.java
+++ b/src/main/java/org/omnifaces/persistence/service/GenericEntityService.java
@@ -218,13 +218,21 @@ public class GenericEntityService {
 
 					if (type.isEnum()) {
 						try {
+							Enum enumValue;
 							boolean negated = searchValue.startsWith("!");
 
 							if (negated) {
 								searchValue = searchValue.substring(1);
 							}
-
-							Enum enumValue = Enum.valueOf((Class<Enum>) type, searchValue.toUpperCase());
+							if(value instanceof Object[]) {
+								if (((Object[]) value).length == 1){
+									enumValue = (Enum) ((Object[]) value)[0];
+								} else {
+									enumValue = Enum.valueOf((Class<Enum>) type, searchValue.toUpperCase());
+								}
+							} else {
+								enumValue = Enum.valueOf((Class<Enum>) type, searchValue.toUpperCase());
+							}
 							searchParameters.put(searchKey, enumValue);
 
 							if (negated) {

--- a/src/main/java/org/omnifaces/persistence/service/GenericEntityService.java
+++ b/src/main/java/org/omnifaces/persistence/service/GenericEntityService.java
@@ -262,7 +262,7 @@ public class GenericEntityService {
 							searchParameters.put(searchKey, null);
 						}
 						else {
-							searchParameters.put(searchKey, null);
+							searchParameters.remove(searchKey);
 						}
 					}
 					else if (Collection.class.isAssignableFrom(type)) {


### PR DESCRIPTION
If type is assignable from a Long and doesn't match any of the other conditions already listed remove the searchKey from parameters so a like searchPredicates is added in the fallback