### PR TITLE
Added functionality for soft deletable entities, minor fixes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>2.21.0</version>
 						<configuration>
+                                                    <trimStackTrace>false</trimStackTrace>
 							<systemPropertyVariables>
 								<jboss.home>${project.build.directory}/wildfly-${test.wildfly.version}</jboss.home>
 								<java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/src/main/java/org/omnifaces/persistence/SoftDeleteType.java
+++ b/src/main/java/org/omnifaces/persistence/SoftDeleteType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence;
+
+import org.omnifaces.persistence.model.SoftDeletable;
+
+/**
+ * Defines the types of the soft delete column.
+ *
+ * @see SoftDeletable
+ *
+ * @author Sergey Kuntsel
+ */
+public enum SoftDeleteType {
+
+    /**
+     * Indicates that the associated column is a column holding active state.
+     * All entities that haven't been soft deleted will thus have true 
+     * in the soft delete column, assuming it was mapped as <code>boolean</code>.
+     */
+    ACTIVE,
+
+    /**
+     * Indicates that the associated column is a column holding deleted state.
+     * All entities that haven't been soft deleted will thus have false 
+     * in the soft delete column, assuming it was mapped as <code>boolean</code>.
+     */
+    DELETED
+
+}

--- a/src/main/java/org/omnifaces/persistence/exception/NonSoftDeletableEntityException.java
+++ b/src/main/java/org/omnifaces/persistence/exception/NonSoftDeletableEntityException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.exception;
+
+import org.omnifaces.persistence.model.BaseEntity;
+
+public class NonSoftDeletableEntityException extends BaseEntityException {
+
+	private static final long serialVersionUID = 1L;
+
+	public NonSoftDeletableEntityException(BaseEntity<?> entity, String message) {
+		super(entity, message);
+	}
+
+}

--- a/src/main/java/org/omnifaces/persistence/model/SoftDeletable.java
+++ b/src/main/java/org/omnifaces/persistence/model/SoftDeletable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.model;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import org.omnifaces.persistence.SoftDeleteType;
+import org.omnifaces.persistence.exception.NonSoftDeletableEntityException;
+import org.omnifaces.persistence.service.BaseEntityService;
+
+/**
+ * <p>
+ * When put on a field of {@link BaseEntity}, then the special methods of {@link BaseEntityService}
+ * will allow to soft-delete the entity and later soft-undelete it. 
+ * It will also allow to get all entities that are soft-deleted and/or active in the data store.
+ * Calling those methods from a service for an entity that doesn't have such column
+ * will throw will throw {@link NonSoftDeletableEntityException}.
+ * 
+ * @author Sergey Kuntsel
+ */
+@Target(value = {METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface SoftDeletable {
+    
+    public SoftDeleteType type() default SoftDeleteType.ACTIVE;
+    
+}

--- a/src/test/java/org/omnifaces/persistence/test/model/Comment.java
+++ b/src/test/java/org/omnifaces/persistence/test/model/Comment.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.model;
+
+import javax.persistence.Entity;
+import static org.omnifaces.persistence.SoftDeleteType.DELETED;
+import org.omnifaces.persistence.model.GeneratedIdEntity;
+import org.omnifaces.persistence.model.SoftDeletable;
+
+@Entity
+public class Comment extends GeneratedIdEntity<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    @SoftDeletable(type = DELETED)
+    private boolean deleted = false;
+
+    public boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+
+}

--- a/src/test/java/org/omnifaces/persistence/test/model/Lookup.java
+++ b/src/test/java/org/omnifaces/persistence/test/model/Lookup.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import static org.omnifaces.persistence.SoftDeleteType.ACTIVE;
+import org.omnifaces.persistence.model.BaseEntity;
+import org.omnifaces.persistence.model.SoftDeletable;
+
+@Entity
+public class Lookup extends BaseEntity<String> {
+    
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(length = 2, nullable = false, unique = true, name = "code")
+    private String id;
+
+    @SoftDeletable(type = ACTIVE)
+    private boolean active = true;
+
+    public Lookup() { }
+    
+    public Lookup(String id) {
+        this.id = id;
+    }
+    
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(String id) {
+        this.id = id;
+    }
+    
+    public boolean getActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+    
+}

--- a/src/test/java/org/omnifaces/persistence/test/model/Text.java
+++ b/src/test/java/org/omnifaces/persistence/test/model/Text.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.model;
+
+import javax.persistence.Entity;
+import static org.omnifaces.persistence.SoftDeleteType.ACTIVE;
+import org.omnifaces.persistence.model.GeneratedIdEntity;
+import org.omnifaces.persistence.model.SoftDeletable;
+
+@Entity
+public class Text extends GeneratedIdEntity<Long> {
+
+    private static final long serialVersionUID = 1L;
+
+    @SoftDeletable(type = ACTIVE)
+    private boolean active = true;
+
+    public boolean getActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+    
+}

--- a/src/test/java/org/omnifaces/persistence/test/service/CommentService.java
+++ b/src/test/java/org/omnifaces/persistence/test/service/CommentService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.service;
+
+import javax.ejb.Stateless;
+
+import org.omnifaces.persistence.service.BaseEntityService;
+import org.omnifaces.persistence.test.model.Comment;
+
+@Stateless
+public class CommentService extends BaseEntityService<Long, Comment> {
+
+}

--- a/src/test/java/org/omnifaces/persistence/test/service/LookupService.java
+++ b/src/test/java/org/omnifaces/persistence/test/service/LookupService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.service;
+
+import javax.ejb.Stateless;
+
+import org.omnifaces.persistence.service.BaseEntityService;
+import org.omnifaces.persistence.test.model.Lookup;
+
+@Stateless
+public class LookupService extends BaseEntityService<String, Lookup> {
+
+}

--- a/src/test/java/org/omnifaces/persistence/test/service/StartupService.java
+++ b/src/test/java/org/omnifaces/persistence/test/service/StartupService.java
@@ -26,10 +26,12 @@ import javax.ejb.Startup;
 import javax.inject.Inject;
 
 import org.omnifaces.persistence.test.model.Address;
+import org.omnifaces.persistence.test.model.Comment;
 import org.omnifaces.persistence.test.model.Gender;
 import org.omnifaces.persistence.test.model.Group;
 import org.omnifaces.persistence.test.model.Person;
 import org.omnifaces.persistence.test.model.Phone;
+import org.omnifaces.persistence.test.model.Text;
 
 @Startup
 @Singleton
@@ -39,11 +41,18 @@ public class StartupService {
 	public static final int ROWS_PER_PAGE = 10;
 
 	@Inject
+	private TextService textService;
+
+	@Inject
+	private CommentService commentService;
+
+	@Inject
 	private PersonService personService;
 
 	@PostConstruct
 	public void init() {
 		createTestPersons();
+                createOtherTestData();
 	}
 
 	private void createTestPersons() {
@@ -81,5 +90,12 @@ public class StartupService {
 			personService.persist(person);
 		}
 	}
+
+        private void createOtherTestData() {
+            textService.persist(new Text());
+            textService.persist(new Text());
+            commentService.persist(new Comment());
+            commentService.persist(new Comment());
+        }
 
 }

--- a/src/test/java/org/omnifaces/persistence/test/service/TextService.java
+++ b/src/test/java/org/omnifaces/persistence/test/service/TextService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.service;
+
+import javax.ejb.Stateless;
+
+import org.omnifaces.persistence.service.BaseEntityService;
+import org.omnifaces.persistence.test.model.Text;
+
+@Stateless
+public class TextService extends BaseEntityService<Long, Text> {
+
+}


### PR DESCRIPTION
Added functionality for soft deletable entities.

In some applications there are requirements that the entities cannot be deleted but rather inactivated, or soft deleted. To account for such requirements a new annotation is introduced, `@SoftDeletable`, where you specify the type of soft delete column.

Herewith two settings are proposed, `SoftDeleteType.ACTIVE` (where you've got an `active` column in the database separating active entities from soft deleted ones) and `SoftDeleteType.DELETED` (where you've got an `deleted` column in the database separating soft deleted entities from active ones). When you place the `@SoftDeletable` annotation on any persistent field of `boolean` type, the `BaseEntityService` will provide for helper methods to soft delete/undelete and get active entity/entities. When these methods are invoked for an entity with no fields marked as soft deleted, a `NonSoftDeletableEntityException` will be thrown.

Example setup:

    @Entity
    public class Text extends GeneratedIdEntity<Long> {

        private static final long serialVersionUID = 1L;

        @SoftDeletable(type = ACTIVE)
        private boolean active = true;

        public boolean getActive() {
            return active;
        }

        public void setActive(boolean active) {
            this.active = active;
        }
    
    }

and

    @Stateless
    public class TextService extends BaseEntityService<Long, Text> {

    }

Example usage:

    public void usage() {
        textService.persist(new Text());
        textService.persist(new Text());
        Text activeText = textService.getById(1L);
        textService.softDelete(activeText); // soft deletes the entity
        textService.getAllDeleted(); // returns a list of all soft deleted entities
        textService.getAllActive(); // returns a list of all active entities
        textService.getActiveById(1L); // returns null
        Text deletedText = textService.getById(1L); // returns soft deleted entity
        textService.softUnelete(activeText); // soft undeletes the entity
        textService.getActiveById(1L); // returns soft undeleted entity
    }

Also, behaviour for calling `BaseEntityService#save` method was modified for entities which ids are not autogenerated. Now, calling this method on such entities doesn't throw `IllegalEntityStateException` but rather calls `BaseEntityService#persist` or `BaseEntityService#update` basing on the result of `BaseEntityService#exists` method call, thus there is no need to manually define which method to call.

This is now the allowed behaviour:

    public void usage() {
        ManualIdEntity entity = new ManualIdEntity("code");
        manualIdEntityService.save(entity); // persists new entity to the data store
        ManualIdEntity persistedEntity = manualIdEntityService.getById("code");
        persistedEntity.setPersistentField("New value");
        manualIdEntityService.save(entity); // merges detached entity to the data store
    }

Test cases for these scenarios were also created.

As a remark, for this to work correctly on the `@MappedSuperclass`-derived entities as well, the `Reflections#accessField` of the omniutils library has to be modified to account for superclass fields as well, i.e. to something like:

    public static <T> T accessField(Object instance, String fieldName) {
        try {
            for (Class<?> cls = instance.getClass(); cls != null; cls = cls.getSuperclass()) {
                Optional<Field> field = Arrays.stream(cls.getDeclaredFields()).filter(f -> f.getName().equals(fieldName)).findFirst();
                if (field.isPresent()) {
                    Field foundField = field.get();
                    foundField.setAccessible(true);
                    return (T) foundField.get(instance);
                }
            }
        } catch (Exception e) {
            throw new IllegalStateException(format(ERROR_ACCESS_FIELD, fieldName, instance.getClass()), e);
        }
        throw new IllegalStateException(format(ERROR_ACCESS_FIELD, fieldName, instance.getClass()));
    }