### PR TITLE
Added functionality for enhanced @Enumerated mapping.

### DIFF
--- a/src/main/java/org/omnifaces/persistence/model/JpaEnum.java
+++ b/src/main/java/org/omnifaces/persistence/model/JpaEnum.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.model;
+
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import javax.persistence.EnumType;
+import org.omnifaces.persistence.service.BaseEntityService;
+
+/**
+ * Basic annotation to change default behaviour of <code>@Enumerated</code>. When this 
+ * annotation is added to the declaration of declaration of custom <code>enum</code> 
+ * then persisting its value by using <code>@Enumerated</code> will be changed. 
+ * If <code>EnumType.ORDINAL</code> is used as <code>type</code> (default) then the enum will 
+ * be persisted basing on <code>fieldName</code> that's holding custom state of 
+ * <code>enum</code> that must correspond to the real property of <code>enum</code> and 
+ * must be of <code>int</code> type, otherwise default mapping will be applied. 
+ * If <code>EnumType.STRING</code> is used as <code>type</code> then the enum 
+ * will be persisted basing on <code>fieldName</code> that must correspond to the real 
+ * property of <code>enum</code> and  must be of <code>String</code> type, otherwise default 
+ * mapping will be applied. 
+ * 
+ * Modified behaviour of <code>@Enumerated</code> 
+ * will be used when the entities are managed by {@link BaseEntityService}. Noted should 
+ * be that when any entity managed by {@link BaseEntityService} uses the <code>enum</code> 
+ * with <code>@JpaEnum</code> applied then it will be persisted in a modified way way even 
+ * when the other entity is not managed by {@link BaseEntityService} to entail consistency.
+ * 
+ * This is particularly useful if you want to avoid drawbacks of standard JPA enum mappings,
+ * like reordering or renaming, by enforcing consistency between enum modifications during 
+ * application development, like addition of new, or removal of old enum values. By using 
+ * this annotation developer has full control of what part of the enum will be mapped to the database.
+ * 
+ * <p>
+ * Usage of this annotation is as follows:
+ * <p>
+ * <pre>
+ *{@literal @}JpaEnum(fieldName = "id")
+ * public enum ProductStatus {
+ * 
+ *     IN_STOCK(1), OUT_OF_STOCK(10), DISCONTINUED(20);
+ * 
+ *     private int id;
+ * 
+ *     private ProductStatus(int id) {
+ *         this.id = id;
+ *     }
+ * 
+ *     public int getId() {
+ *         return id;
+ *     }
+ * 
+ * }
+ * </pre>
+ * 
+ * and
+ * <p>
+ * <pre>
+ *{@literal @}JpaEnum(type = EnumType.STRING, fieldName = "code")
+ * public enum UserRole {
+ * 
+ *     USER("USR"), EMPLOYEE("EMP"), MANAGER("MGR");
+ * 
+ *     private String code;
+ * 
+ *     private UserRole(String code) {
+ *         this.code = code;
+ *     }
+ * 
+ *     public String getCode() {
+ *         return code;
+ *     }
+ * 
+ * }
+ * </pre>
+ * 
+ * with 
+ * <p>
+ * <pre>
+ *{@literal @}Entity
+ * public class Product extends GeneratedIdEntity&lt;Long&gt; {
+ * 
+ *     ...
+ *    {@literal @}Enumerated
+ *     private ProductStatus productStatus;
+ * 
+ *    {@literal @}ElementCollection
+ *    {@literal @}Enumerated(STRING)
+ *     private Set&lt;UserRole&gt; userRoles = new HashSet&lt;&gt;();
+ *     ...
+ * 
+ * }
+ * </pre>
+ * 
+ * In such setup persistence provider will save to the database the status as either 
+ * 1, 10 or 20 (as opposed to 0, 1 or 2) and role as either USR, EMP or MGR (as opposed to
+ * USER, EMPLOYEE or MANAGER).
+ * 
+ * @author Sergey Kuntsel
+ */
+@Target(value = { TYPE })
+@Retention(RUNTIME)
+public @interface JpaEnum {
+
+    /*
+     * Type of mapping between enum and database.
+     */
+    public EnumType type() default EnumType.ORDINAL;
+
+    /*
+     * Corresponding field name of enum.
+     */
+    public String fieldName();
+    
+}

--- a/src/main/java/org/omnifaces/persistence/model/JpaEnumSpecifics.java
+++ b/src/main/java/org/omnifaces/persistence/model/JpaEnumSpecifics.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.model;
+
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import javax.persistence.EnumType;
+
+/**
+ * TODO implement additional annotation to fine-tune correspondence between JPA enum and database table.
+ *
+ * @author Sergey Kuntsel
+ */
+@Target(value = { TYPE })
+@Retention(RUNTIME)
+public @interface JpaEnumSpecifics {
+    
+    public String tableName() default "";
+    public String ordinalColumnName() default "";
+    public String stringColumnName() default "";
+    public String ordinalFieldName() default "";
+    public String stringFieldName() default "";
+    public boolean updateTableAtStartup() default false;
+    public boolean tablePriority() default false;
+    
+}

--- a/src/test/java/org/omnifaces/persistence/test/OmniPersistenceTest.java
+++ b/src/test/java/org/omnifaces/persistence/test/OmniPersistenceTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,10 +40,14 @@ import org.omnifaces.persistence.test.model.Comment;
 import org.omnifaces.persistence.test.model.Gender;
 import org.omnifaces.persistence.test.model.Lookup;
 import org.omnifaces.persistence.test.model.Person;
+import org.omnifaces.persistence.test.model.Product;
+import org.omnifaces.persistence.test.model.ProductStatus;
 import org.omnifaces.persistence.test.model.Text;
+import org.omnifaces.persistence.test.model.UserRole;
 import org.omnifaces.persistence.test.service.CommentService;
 import org.omnifaces.persistence.test.service.LookupService;
 import org.omnifaces.persistence.test.service.PersonService;
+import org.omnifaces.persistence.test.service.ProductService;
 import org.omnifaces.persistence.test.service.TextService;
 
 @RunWith(Arquillian.class)
@@ -73,6 +78,8 @@ public class OmniPersistenceTest {
 	@EJB
 	private LookupService lookupService;
 
+	@EJB
+	private ProductService productService;
 
 	// Basic ----------------------------------------------------------------------------------------------------------
 
@@ -292,4 +299,21 @@ public class OmniPersistenceTest {
 		lookupService.update(lookup);
 	}
 
+        @Test
+        public void testPersistedEntitiesWithEnums() {
+                Product product = productService.getByIdWithUserRoles(1L);
+                assertTrue("Product status for product 1 was persisted", product.getProductStatus() == ProductStatus.IN_STOCK);
+                assertTrue("Product status id for product 1 was persisted", productService.getRawProductStatus(product.getId()) == ProductStatus.IN_STOCK.getId());
+                assertTrue("User roles for product 1 were persisted", product.getUserRoles().size() == 1 && product.getUserRoles().contains(UserRole.USER));
+                assertTrue("User roles code for product 1 were persisted", productService.getRawUserRoles(product.getId()).contains(UserRole.USER.getCode()));
+                
+                product = productService.getByIdWithUserRoles(2L);
+                assertTrue("Product status for product 2 was persisted", product.getProductStatus() == ProductStatus.DISCONTINUED);
+                assertTrue("User roles for product 2 were persisted", product.getUserRoles().size() == 2 && 
+                        product.getUserRoles().contains(UserRole.EMPLOYEE) && product.getUserRoles().contains(UserRole.MANAGER));
+                assertTrue("Product status id for product 2 was persisted", productService.getRawProductStatus(product.getId()) == ProductStatus.DISCONTINUED.getId());
+                assertTrue("User roles code for product 2 were persisted", productService.getRawUserRoles(product.getId()).containsAll(
+                        Arrays.asList(new String[] { UserRole.EMPLOYEE.getCode(), UserRole.MANAGER.getCode() })));
+        }
+        
 }

--- a/src/test/java/org/omnifaces/persistence/test/model/Product.java
+++ b/src/test/java/org/omnifaces/persistence/test/model/Product.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.model;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import static javax.persistence.EnumType.STRING;
+import javax.persistence.Enumerated;
+import org.omnifaces.persistence.model.GeneratedIdEntity;
+
+@Entity
+public class Product extends GeneratedIdEntity<Long> {
+
+    private static final long serialVersionUID = 1L;
+    
+    @Enumerated
+    private ProductStatus productStatus;
+
+    @ElementCollection
+    @Enumerated(STRING)
+    private Set<UserRole> userRoles = new HashSet<>();
+
+    public ProductStatus getProductStatus() {
+        return productStatus;
+    }
+
+    public void setProductStatus(ProductStatus productStatus) {
+        this.productStatus = productStatus;
+    }
+
+    public Set<UserRole> getUserRoles() {
+        return userRoles;
+    }
+
+    public void setUserRoles(Set<UserRole> userRoles) {
+        this.userRoles = userRoles;
+    }
+    
+    public void addUserRole(UserRole userRole) {
+        userRoles.add(userRole);
+    }
+
+}

--- a/src/test/java/org/omnifaces/persistence/test/model/ProductStatus.java
+++ b/src/test/java/org/omnifaces/persistence/test/model/ProductStatus.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.model;
+
+import org.omnifaces.persistence.model.JpaEnum;
+
+@JpaEnum(fieldName = "id")
+public enum ProductStatus {
+    
+    IN_STOCK(1), OUT_OF_STOCK(10), DISCONTINUED(20);
+    
+    private int id;
+
+    private ProductStatus(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+}

--- a/src/test/java/org/omnifaces/persistence/test/model/UserRole.java
+++ b/src/test/java/org/omnifaces/persistence/test/model/UserRole.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.model;
+
+import javax.persistence.EnumType;
+import org.omnifaces.persistence.model.JpaEnum;
+
+@JpaEnum(type = EnumType.STRING, fieldName = "code")
+public enum UserRole {
+    
+    USER("USR"), EMPLOYEE("EMP"), MANAGER("MGR");
+    
+    private String code;
+
+    private UserRole(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+    
+}

--- a/src/test/java/org/omnifaces/persistence/test/service/ProductService.java
+++ b/src/test/java/org/omnifaces/persistence/test/service/ProductService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.test.service;
+
+import java.util.List;
+import javax.ejb.Stateless;
+
+import org.omnifaces.persistence.service.BaseEntityService;
+import org.omnifaces.persistence.test.model.Product;
+
+@Stateless
+public class ProductService extends BaseEntityService<Long, Product> {
+
+    public Product getByIdWithUserRoles(Long id) {
+        return getEntityManager()
+                .createQuery("SELECT p FROM Product p JOIN FETCH p.userRoles WHERE p.id = :id", Product.class)
+                .setParameter("id", id)
+                .getSingleResult();
+    }
+
+    public List<Product> getAllWithUserRoles() {
+        return getEntityManager()
+                .createQuery("SELECT p FROM Product p JOIN FETCH p.userRoles", Product.class)
+                .getResultList();
+    }
+    
+    public int getRawProductStatus(Long id) {
+        int statusCode = (int)getEntityManager().createNativeQuery("SELECT p.productStatus FROM product p WHERE p.id = :id")
+                .setParameter("id", id)
+                .getSingleResult();
+        return statusCode;
+    }
+    
+    public List<String> getRawUserRoles(Long id) {
+        List<String> userRoles = (List<String>)getEntityManager()
+                .createNativeQuery("SELECT pu.userRoles FROM product p INNER JOIN product_userRoles pu on pu.product_id = p.id WHERE p.id = :id")//SELECT pu.userRoles FROM Product_userRoles pu RIGHT JOIN Product p WHERE p.id = :id")
+                .setParameter("id", id)
+                .getResultList();
+        return userRoles;
+    }
+    
+}

--- a/src/test/java/org/omnifaces/persistence/test/service/StartupService.java
+++ b/src/test/java/org/omnifaces/persistence/test/service/StartupService.java
@@ -31,7 +31,10 @@ import org.omnifaces.persistence.test.model.Gender;
 import org.omnifaces.persistence.test.model.Group;
 import org.omnifaces.persistence.test.model.Person;
 import org.omnifaces.persistence.test.model.Phone;
+import org.omnifaces.persistence.test.model.Product;
+import org.omnifaces.persistence.test.model.ProductStatus;
 import org.omnifaces.persistence.test.model.Text;
+import org.omnifaces.persistence.test.model.UserRole;
 
 @Startup
 @Singleton
@@ -49,11 +52,15 @@ public class StartupService {
 	@Inject
 	private PersonService personService;
 
+	@Inject
+	private ProductService productService;
+
 	@PostConstruct
 	public void init() {
 		createTestPersons();
 		createTestTexts();
 		createTestComments();
+                createTestProducts();
 	}
 
 	private void createTestPersons() {
@@ -101,5 +108,18 @@ public class StartupService {
 		commentService.persist(new Comment());
 		commentService.persist(new Comment());
 	}
+
+        private void createTestProducts() {
+                Product product = new Product();
+                product.setProductStatus(ProductStatus.IN_STOCK);
+                product.addUserRole(UserRole.USER);
+                productService.persist(product);
+                
+                product = new Product();
+                product.setProductStatus(ProductStatus.DISCONTINUED);
+                product.addUserRole(UserRole.EMPLOYEE);
+                product.addUserRole(UserRole.MANAGER);
+                productService.persist(product);
+        }
 
 }


### PR DESCRIPTION
Added basic functionality for enhanced enum mapping that empowers standard JPA `@Enumerated` mapping via `@JpaEnum` annotation.

When used in conjunction with `@Enumerated(ORDINAL)` `@JpaEnum` allows developer to specify `fieldName` of type `Integer`/`int` of application enum that will be persisted to the database, instead of the standard `ordinal` of a particular enum.

When used in conjunction with `@Enumerated(STRING)` `@JpaEnum` allows developer to specify `fieldName` of type `String` of application enum that will be persisted to the database, instead of the standard `name` of a particular enum.

This allows to create more robust applications with the ability to modify/add/delete enum instances during application development, thus alleviating the vulnerabilities of standard JPA `@Enumerated`.

Its usage is as follows:

    @JpaEnum(fieldName = "id")
    public enum ProductStatus {
    
        IN_STOCK(1), OUT_OF_STOCK(10), DISCONTINUED(20);
    
        private int id;

        private ProductStatus(int id) {
            this.id = id;
        }

        public int getId() {
            return id;
        }

    }

and

    @JpaEnum(type = EnumType.STRING, fieldName = "code")
    public enum UserRole {
    
        USER("USR"), EMPLOYEE("EMP"), MANAGER("MGR");
    
        private String code;

        private UserRole(String code) {
            this.code = code;
        }

        public String getCode() {
            return code;
        }
    
    }

with

    @Entity
    public class Product extends GeneratedIdEntity<Long> {

        private static final long serialVersionUID = 1L;
    
        @Enumerated
        private ProductStatus productStatus;

        @ElementCollection
        @Enumerated(STRING)
        private Set<UserRole> userRoles = new HashSet<>();

        public ProductStatus getProductStatus() {
            return productStatus;
        }

        public void setProductStatus(ProductStatus productStatus) {
            this.productStatus = productStatus;
        }

        public Set<UserRole> getUserRoles() {
            return userRoles;
        }

        public void setUserRoles(Set<UserRole> userRoles) {
            this.userRoles = userRoles;
        }
    
        public void addUserRole(UserRole userRole) {
            userRoles.add(userRole);
        }

    }

With such setup persistence provider will save to the database the status as either 1, 10 or 20 (as opposed to the default 0, 1 or 2 otherwise) and role as either USR, EMP or MGR (as opposed to default USER, EMPLOYEE or MANAGER otherwise).

This may be evolved even further with another, yet to be done, annotation `@JpaEnumSpecifics` that will define the correlation with the database lookup table for each enum used and will do, among others, the following:
- issue warnings in case there is no one-to-one correlation between the enum class and the database table;
- update database table basing on the current enum code, or update enum code basing on the database table;
- create and fill in database tables.