### PR TITLE
Enable JPA Metamodel Generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 			<artifactId>omniutils</artifactId>
 			<version>0.9-SNAPSHOT</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-jpamodelgen</artifactId>
+			<version>5.3.0.Final</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Make it possible to use JPA Metamodel generation for classes extending `BaseEntity`.

See for documentation: http://docs.jboss.org/hibernate/orm/5.3/topical/html_single/metamodelgen/MetamodelGenerator.html