### PR TITLE
Add and use MappedPathResolver with a fallback on RootPathResolver

### DIFF
--- a/src/main/java/org/omnifaces/persistence/service/BaseEntityService.java
+++ b/src/main/java/org/omnifaces/persistence/service/BaseEntityService.java
@@ -1723,7 +1723,7 @@ public abstract class BaseEntityService<I extends Comparable<I> & Serializable, 
 			boolean orderingContainsAggregatedFields = aggregatedFields.removeAll(pageBuilder.getPage().getOrdering().keySet());
 			pageBuilder.shouldBuildCountSubquery(true); // Normally, building of count subquery is skipped for performance, but when there's a custom mapping, we cannot reliably determine if custom criteria is used, so count subquery building cannot be reliably skipped.
 			pageBuilder.canBuildValueBasedPagingPredicate(provider != HIBERNATE || !orderingContainsAggregatedFields); // Value based paging cannot be used in Hibernate if ordering contains aggregated fields, because Hibernate may return a cartesian product and apply firstResult/maxResults in memory.
-			return field -> (field == null) ? root : paths.get(field);
+			return new MappedPathResolver(root, paths, ELEMENT_COLLECTION_MAPPINGS.get(entityType), MANY_OR_ONE_TO_ONE_MAPPINGS.get(entityType));
 		}
 		else if (pageBuilder.getResultType() == entityType) {
 			pageBuilder.shouldBuildCountSubquery(mapping != null); // mapping is empty but not null when getPage(..., QueryBuilder) is used.

--- a/src/main/java/org/omnifaces/persistence/service/MappedPathResolver.java
+++ b/src/main/java/org/omnifaces/persistence/service/MappedPathResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.persistence.service;
+
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class MappedPathResolver implements PathResolver {
+
+	private final Root<?> root;
+	private final Map<String, Expression<?>> paths;
+	private final RootPathResolver rootPathResolver;
+
+	public MappedPathResolver(Root<?> root, Map<String, Expression<?>> paths, Set<String> elementCollections, Set<String> manyOrOneToOnes) {
+		this.root = root;
+		this.paths = paths;
+		this.rootPathResolver = new RootPathResolver(root, elementCollections, manyOrOneToOnes);
+	}
+
+	@Override
+	public Expression<?> get(String field) {
+		if (field == null) {
+			return root;
+		}
+
+		Expression<?> path = paths.get(field);
+
+		if (path != null) {
+			return path;
+		} else {
+			return rootPathResolver.get(field);
+		}
+	}
+}


### PR DESCRIPTION
When using a mapping (to get a DTO that extends an Entity) it's currently not possible to add predicates for not-mapped fields. By using a fallback on the RootPathResolver this becomes possible, making more filtering from the frontend possible without the need for adding custom Criteria in the backend.